### PR TITLE
fix: improve handler setup error guidance

### DIFF
--- a/src/handlers/document-handlers.ts
+++ b/src/handlers/document-handlers.ts
@@ -24,6 +24,28 @@ import {
 	documentTitleSchema,
 } from './validation-schemas.js';
 
+function assertValidDocumentId(documentId: string): void {
+	if (!isValidUUID(documentId)) {
+		throw createError(
+			ErrorCode.INVALID_INPUT,
+			{ documentId },
+			`Invalid document ID format: "${documentId}". Use get_structure or get_all_documents to find a valid Scrivener UUID.`
+		);
+	}
+}
+
+async function requireExistingDocument(project: ReturnType<typeof requireProject>, documentId: string) {
+	const info = await project.getDocumentInfo(documentId);
+	if (!info.document) {
+		throw createError(
+			ErrorCode.DOCUMENT_NOT_FOUND,
+			{ documentId },
+			`Document "${documentId}" was not found in the open project. Use get_structure or get_all_documents to choose a valid document ID.`
+		);
+	}
+	return info;
+}
+
 export const getDocumentInfoHandler: ToolDefinition = {
 	name: 'get_document_info',
 	description: 'Get detailed information about a document including parent hierarchy',
@@ -40,20 +62,9 @@ export const getDocumentInfoHandler: ToolDefinition = {
 	handler: async (args, _context): Promise<HandlerResult> => {
 		try {
 			const project = requireProject(_context);
-			validateInput(args, documentIdSchema);
-
 			const documentId = getStringArg(args, 'documentId');
-
-			// Validate UUID format
-			if (!isValidUUID(documentId)) {
-				throw createError(
-					ErrorCode.INVALID_INPUT,
-					{ documentId },
-					'Invalid document ID format'
-				);
-			}
-
-			const info = await measureExecution(() => project.getDocumentInfo(documentId));
+			assertValidDocumentId(documentId);
+			const info = await measureExecution(() => requireExistingDocument(project, documentId));
 
 			return {
 				content: [
@@ -86,25 +97,15 @@ export const readDocumentHandler: ToolDefinition = {
 	handler: async (args, _context): Promise<HandlerResult> => {
 		try {
 			const project = requireProject(_context);
-			validateInput(args, documentIdSchema);
-
 			const documentId = getStringArg(args, 'documentId');
-
-			// Validate UUID format
-			if (!isValidUUID(documentId)) {
-				throw createError(
-					ErrorCode.INVALID_INPUT,
-					{ documentId },
-					'Invalid document ID format'
-				);
-			}
+			assertValidDocumentId(documentId);
+			const docInfo = await requireExistingDocument(project, documentId);
 
 			const result = await measureExecution(() => project.readDocument(documentId));
 
 			// Optionally memorize document content in HHM
 			try {
 				const hhmSystem = getHHMSystem();
-				const docInfo = await project.getDocumentInfo(documentId);
 				if (docInfo.document && result.result.trim()) {
 					await hhmSystem.memorizeDocument({
 						id: docInfo.document.id,

--- a/src/handlers/project-handlers.ts
+++ b/src/handlers/project-handlers.ts
@@ -5,7 +5,7 @@
 import * as path from 'path';
 import { MemoryManager } from '../memory-manager.js';
 import { ScrivenerProject } from '../scrivener-project.js';
-import { validateInput } from '../utils/common.js';
+import { validateInput, createError, ErrorCode } from '../utils/common.js';
 import { resolveScrivenerProjectPath } from '../utils/scrivener-utils.js';
 import { DatabaseService } from './database/database-service.js';
 import type { HandlerResult, ToolDefinition } from './types.js';
@@ -53,7 +53,19 @@ export const openProjectHandler: ToolDefinition = {
 			hhmSystem: context.hhmSystem,
 			scrivxPath,
 		});
-		await project.loadProject();
+		try {
+			await project.loadProject();
+		} catch (error) {
+			const expectedScrivxPath = path.join(
+				projectPath,
+				`${path.basename(projectPath, path.extname(projectPath))}.scrivx`
+			);
+			throw createError(
+				ErrorCode.PROJECT_NOT_FOUND,
+				{ path: projectPath, expectedScrivxPath, cause: error },
+				`Could not open Scrivener project at "${projectPath}". Expected to find "${expectedScrivxPath}". Pass the .scriv project folder or its .scrivx file.`
+			);
+		}
 
 		// Initialize database service
 		const dbService = new DatabaseService(projectPath);

--- a/tests/unit/handler-error-messages.test.ts
+++ b/tests/unit/handler-error-messages.test.ts
@@ -1,0 +1,156 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { getDocumentInfoHandler, readDocumentHandler } from '../../src/handlers/document-handlers.js';
+import { openProjectHandler } from '../../src/handlers/project-handlers.js';
+import type { HandlerContext } from '../../src/handlers/types.js';
+import { DatabaseService } from '../../src/handlers/database/database-service.js';
+import { MemoryManager } from '../../src/memory-manager.js';
+import { ScrivenerProject } from '../../src/scrivener-project.js';
+import { ErrorCode } from '../../src/utils/common.js';
+
+jest.mock('../../src/scrivener-project.js', () => ({
+	ScrivenerProject: jest.fn(),
+}));
+
+jest.mock('../../src/handlers/database/database-service.js', () => ({
+	DatabaseService: jest.fn(),
+}));
+
+jest.mock('../../src/memory-manager.js', () => ({
+	MemoryManager: jest.fn(),
+}));
+
+jest.mock('../../src/handlers/memory-handlers.js', () => ({
+	getHHMSystem: jest.fn(() => ({
+		memorizeDocument: jest.fn().mockResolvedValue(undefined),
+	})),
+}));
+
+jest.mock('../../src/core/logger.js', () => ({
+	getLogger: jest.fn(() => ({
+		debug: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	})),
+}));
+
+const validDocumentId = '123e4567-e89b-42d3-a456-426614174000';
+
+function createContext(project: HandlerContext['project']): HandlerContext {
+	return {
+		project,
+		memoryManager: null,
+		contentAnalyzer: {} as HandlerContext['contentAnalyzer'],
+		contentEnhancer: {} as HandlerContext['contentEnhancer'],
+	};
+}
+
+describe('handler error messages', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		(ScrivenerProject as unknown as jest.Mock).mockImplementation(() => ({
+			loadProject: jest.fn().mockResolvedValue(undefined),
+			getProjectMetadata: jest.fn().mockResolvedValue({ title: 'Novel' }),
+			close: jest.fn().mockResolvedValue(undefined),
+		}));
+
+		(DatabaseService as unknown as jest.Mock).mockImplementation(() => ({
+			initialize: jest.fn().mockResolvedValue(undefined),
+		}));
+
+		(MemoryManager as unknown as jest.Mock).mockImplementation(() => ({
+			initialize: jest.fn().mockResolvedValue(undefined),
+		}));
+	});
+
+	it('accepts a direct .scrivx path for open_project', async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'scrivener-mcp-'));
+		const projectDir = path.join(tempRoot, 'Novel.scriv');
+		const scrivxPath = path.join(projectDir, 'Novel.scrivx');
+
+		await fs.mkdir(projectDir, { recursive: true });
+		await fs.writeFile(scrivxPath, '<ScrivenerProject><Binder /></ScrivenerProject>');
+
+		await openProjectHandler.handler(
+			{ path: scrivxPath },
+			createContext(null)
+		);
+
+		expect(ScrivenerProject).toHaveBeenCalledWith(
+			projectDir,
+			expect.objectContaining({ hhmSystem: undefined })
+		);
+	});
+
+	it('explains when open_project receives a parent folder instead of the project path', async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'scrivener-mcp-parent-'));
+		await fs.writeFile(
+			path.join(tempRoot, 'Novel.scrivx'),
+			'<ScrivenerProject><Binder /></ScrivenerProject>'
+		);
+
+		await expect(
+			openProjectHandler.handler({ path: tempRoot }, createContext(null))
+		).rejects.toMatchObject({
+			code: ErrorCode.INVALID_INPUT,
+			message: expect.stringContaining('looks like a parent folder'),
+		});
+	});
+
+	it('surfaces actionable invalid UUID guidance for read_document', async () => {
+		const context = createContext({
+			getDocumentInfo: jest.fn(),
+			readDocument: jest.fn(),
+		} as unknown as HandlerContext['project']);
+
+		await expect(
+			readDocumentHandler.handler({ documentId: 'not-a-uuid' }, context)
+		).rejects.toMatchObject({
+			code: ErrorCode.INVALID_INPUT,
+			message: expect.stringContaining('get_structure or get_all_documents'),
+		});
+	});
+
+	it('throws a document-not-found error instead of returning null metadata', async () => {
+		const context = createContext({
+			getDocumentInfo: jest.fn().mockResolvedValue({
+				document: null,
+				path: [],
+				metadata: {},
+				location: 'unknown',
+			}),
+		} as unknown as HandlerContext['project']);
+
+		await expect(
+			getDocumentInfoHandler.handler({ documentId: validDocumentId }, context)
+		).rejects.toMatchObject({
+			code: ErrorCode.DOCUMENT_NOT_FOUND,
+			message: expect.stringContaining('Use get_structure or get_all_documents'),
+		});
+	});
+
+	it('blocks read_document when the document does not exist in the open project', async () => {
+		const project = {
+			getDocumentInfo: jest.fn().mockResolvedValue({
+				document: null,
+				path: [],
+				metadata: {},
+				location: 'unknown',
+			}),
+			readDocument: jest.fn(),
+		};
+		const context = createContext(project as unknown as HandlerContext['project']);
+
+		await expect(
+			readDocumentHandler.handler({ documentId: validDocumentId }, context)
+		).rejects.toMatchObject({
+			code: ErrorCode.DOCUMENT_NOT_FOUND,
+			message: expect.stringContaining('was not found in the open project'),
+		});
+		expect(project.readDocument).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- accept direct `.scrivx` paths for `open_project` and explain when users point at the parent folder instead of the Scrivener project
- turn null document lookups into actionable `DOCUMENT_NOT_FOUND` handler errors and improve invalid UUID guidance
- add handler tests covering the new path normalization and document error messages

## Validation
- `npm test -- --runTestsByPath tests/unit/handler-error-messages.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run lint` *(blocked by existing repo config: `eslint.config.js` imports `@eslint/js`, but that package is not present in `package.json`)*

Closes #10.
