### PR TITLE
Fix Windows Scrivener project path discovery

### DIFF
--- a/src/handlers/project-handlers.ts
+++ b/src/handlers/project-handlers.ts
@@ -5,13 +5,8 @@
 import * as path from 'path';
 import { MemoryManager } from '../memory-manager.js';
 import { ScrivenerProject } from '../scrivener-project.js';
-import {
-	validateInput,
-	pathExists,
-	sanitizePath,
-	createError,
-	ErrorCode,
-} from '../utils/common.js';
+import { validateInput } from '../utils/common.js';
+import { resolveScrivenerProjectPath } from '../utils/scrivener-utils.js';
 import { DatabaseService } from './database/database-service.js';
 import type { HandlerResult, ToolDefinition } from './types.js';
 import {
@@ -46,16 +41,7 @@ export const openProjectHandler: ToolDefinition = {
 		});
 
 		const rawPath = getStringArg(args, 'path');
-		const projectPath = sanitizePath(rawPath);
-
-		// Verify the path exists
-		if (!(await pathExists(projectPath))) {
-			throw createError(
-				ErrorCode.FILE_NOT_FOUND,
-				{ path: projectPath },
-				`Project path does not exist: ${projectPath}`
-			);
-		}
+		const { projectPath, scrivxPath } = await resolveScrivenerProjectPath(rawPath);
 
 		// Close existing project
 		if (context.project) {
@@ -65,6 +51,7 @@ export const openProjectHandler: ToolDefinition = {
 		// Initialize new project
 		const project = new ScrivenerProject(projectPath, {
 			hhmSystem: context.hhmSystem,
+			scrivxPath,
 		});
 		await project.loadProject();
 

--- a/src/scrivener-project.ts
+++ b/src/scrivener-project.ts
@@ -48,6 +48,7 @@ export interface ScrivenerProjectOptions {
 	autoBackup?: boolean;
 	cacheSize?: number;
 	syncInterval?: number;
+	scrivxPath?: string;
 	hhmSystem?: HolographicMemorySystem;
 }
 
@@ -81,6 +82,7 @@ export class ScrivenerProject {
 		this.documentManager = new DocumentManager(this.projectPath);
 		this.projectLoader = new ProjectLoader(this.projectPath, {
 			autoBackup: this.options.autoBackup,
+			scrivxPath: this.options.scrivxPath,
 		});
 		this.compilationService = new CompilationService();
 		this.metadataManager = new MetadataManager();

--- a/src/services/project-loader.ts
+++ b/src/services/project-loader.ts
@@ -16,7 +16,8 @@ import {
 	safeWriteFile,
 	buildPath,
 } from '../utils/common.js';
-import { FileUtils, PathUtils } from '../utils/shared-patterns.js';
+import { FileUtils } from '../utils/shared-patterns.js';
+import { findScrivxPath, getDefaultScrivxPath } from '../utils/scrivener-utils.js';
 
 const logger = getLogger('project-loader');
 
@@ -24,6 +25,7 @@ export interface ProjectLoaderOptions {
 	autoBackup?: boolean;
 	backupInterval?: number;
 	maxBackups?: number;
+	scrivxPath?: string;
 }
 
 export class ProjectLoader {
@@ -40,17 +42,9 @@ export class ProjectLoader {
 		}
 
 		this.projectPath = path.resolve(projectPath);
-
-		const ext = path.extname(this.projectPath).toLowerCase();
-		if (ext !== '.scriv') {
-			throw createError(
-				ErrorCode.INVALID_INPUT,
-				`Project path must have a .scriv extension, got "${ext || 'none'}"`
-			);
-		}
-
-		const projectName = path.basename(projectPath, path.extname(projectPath));
-		this.scrivxPath = PathUtils.build(this.projectPath, `${projectName}.scrivx`);
+		this.scrivxPath = options.scrivxPath
+			? path.resolve(options.scrivxPath)
+			: getDefaultScrivxPath(this.projectPath);
 		this.options = {
 			autoBackup: false,
 			backupInterval: 3600000, // 1 hour
@@ -63,6 +57,7 @@ export class ProjectLoader {
 	 * Load the project structure from disk
 	 */
 	async loadProject(): Promise<ProjectStructure> {
+		this.scrivxPath = await findScrivxPath(this.projectPath, this.scrivxPath);
 		logger.info(`Loading project from ${this.scrivxPath}`);
 
 		try {

--- a/src/utils/project-utils.ts
+++ b/src/utils/project-utils.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { getLogger } from '../core/logger.js';
 import { FileUtils, PathUtils, AsyncUtils } from './shared-patterns.js';
 import { AppError, ErrorCode } from './common.js';
+import { findScrivxPath } from './scrivener-utils.js';
 
 const logger = getLogger('project-utils');
 
@@ -28,9 +29,8 @@ const _DEFAULT_CACHE_CONFIG: CacheConfig = {
  */
 async function isScrivenerProject(projectPath: string): Promise<boolean> {
 	try {
-		const projectFile = PathUtils.build(projectPath, 'project.scrivx');
-		const stats = await fs.stat(projectFile);
-		return stats.isFile();
+		await findScrivxPath(projectPath);
+		return true;
 	} catch {
 		return false;
 	}

--- a/src/utils/scrivener-utils.ts
+++ b/src/utils/scrivener-utils.ts
@@ -1,4 +1,6 @@
 import * as crypto from 'crypto';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import {
 	validateInput,
 	isValidUUID,
@@ -42,6 +44,167 @@ export const SCRIVENER_LIMITS = {
 	MAX_SYNOPSIS_LENGTH: 5000,
 	MAX_NOTES_LENGTH: 100000,
 } as const;
+
+export interface ResolvedScrivenerProjectPath {
+	projectPath: string;
+	scrivxPath: string;
+}
+
+// ============================================================================
+// Project Path Utilities
+// ============================================================================
+
+/**
+ * Normalize a project path while preserving native Windows drive-letter paths.
+ */
+export function normalizeScrivenerPath(inputPath: string): string {
+	if (!inputPath) {
+		throw new AppError('Project path is required', ErrorCode.INVALID_INPUT);
+	}
+
+	return path.resolve(path.normalize(inputPath.replace(/\0/g, '')));
+}
+
+/**
+ * Return the Scrivener project name without .scriv or .scrivx.
+ */
+export function getScrivenerProjectName(projectPath: string): string {
+	const normalizedPath = path.normalize(projectPath.replace(/\0/g, ''));
+	const extension = path.extname(normalizedPath);
+	const lowerExtension = extension.toLowerCase();
+
+	if (
+		lowerExtension === SCRIVENER_EXTENSIONS.PROJECT ||
+		lowerExtension === SCRIVENER_EXTENSIONS.XML
+	) {
+		return path.basename(normalizedPath, extension);
+	}
+
+	return path.basename(normalizedPath);
+}
+
+/**
+ * Build the default .scrivx path for a .scriv project directory.
+ */
+export function getDefaultScrivxPath(projectPath: string): string {
+	const normalizedPath = normalizeScrivenerPath(projectPath);
+
+	if (path.extname(normalizedPath).toLowerCase() === SCRIVENER_EXTENSIONS.XML) {
+		return normalizedPath;
+	}
+
+	return path.join(normalizedPath, `${getScrivenerProjectName(normalizedPath)}.scrivx`);
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+	try {
+		return (await fs.stat(filePath)).isFile();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Discover the .scrivx file inside a Scrivener project directory.
+ *
+ * Scrivener projects usually use <ProjectName>.scriv/<ProjectName>.scrivx, but
+ * migrated projects and case-different Windows folders can carry a different
+ * casing or a single alternate .scrivx file. Prefer explicit/default names and
+ * then fall back only when there is exactly one .scrivx candidate.
+ */
+export async function findScrivxPath(
+	projectPath: string,
+	preferredScrivxPath?: string
+): Promise<string> {
+	const normalizedProjectPath = normalizeScrivenerPath(projectPath);
+	const defaultScrivxPath = getDefaultScrivxPath(normalizedProjectPath);
+
+	if (preferredScrivxPath) {
+		const normalizedPreferredPath = normalizeScrivenerPath(preferredScrivxPath);
+		if (await isFile(normalizedPreferredPath)) {
+			return normalizedPreferredPath;
+		}
+	}
+
+	const entries = await fs.readdir(normalizedProjectPath, { withFileTypes: true });
+	const scrivxEntries = entries.filter(
+		(entry) =>
+			entry.isFile() && path.extname(entry.name).toLowerCase() === SCRIVENER_EXTENSIONS.XML
+	);
+
+	const defaultScrivxName = path.basename(defaultScrivxPath).toLowerCase();
+	const defaultEntry = scrivxEntries.find(
+		(entry) => entry.name.toLowerCase() === defaultScrivxName
+	);
+	if (defaultEntry) {
+		return path.join(normalizedProjectPath, defaultEntry.name);
+	}
+
+	const projectName = getScrivenerProjectName(normalizedProjectPath).toLowerCase();
+	const matchingEntry = scrivxEntries.find(
+		(entry) => path.basename(entry.name, path.extname(entry.name)).toLowerCase() === projectName
+	);
+	if (matchingEntry) {
+		return path.join(normalizedProjectPath, matchingEntry.name);
+	}
+
+	if (scrivxEntries.length === 1) {
+		return path.join(normalizedProjectPath, scrivxEntries[0].name);
+	}
+
+	throw new AppError(
+		`Scrivener project file not found at "${defaultScrivxPath}"`,
+		ErrorCode.NOT_FOUND,
+		{ projectPath: normalizedProjectPath, expectedScrivxPath: defaultScrivxPath }
+	);
+}
+
+/**
+ * Resolve either a .scriv directory or direct .scrivx file to both paths.
+ */
+export async function resolveScrivenerProjectPath(
+	inputPath: string
+): Promise<ResolvedScrivenerProjectPath> {
+	const normalizedPath = normalizeScrivenerPath(inputPath);
+	const stats = await fs.stat(normalizedPath).catch((error: unknown) => {
+		throw new AppError(
+			`Project path does not exist: ${normalizedPath}`,
+			ErrorCode.FILE_NOT_FOUND,
+			{
+				path: normalizedPath,
+				cause: error,
+			}
+		);
+	});
+
+	if (stats.isFile()) {
+		if (path.extname(normalizedPath).toLowerCase() !== SCRIVENER_EXTENSIONS.XML) {
+			throw new AppError(
+				`Expected a .scriv project folder or .scrivx file: ${normalizedPath}`,
+				ErrorCode.INVALID_INPUT,
+				{ path: normalizedPath }
+			);
+		}
+
+		return {
+			projectPath: path.dirname(normalizedPath),
+			scrivxPath: normalizedPath,
+		};
+	}
+
+	if (!stats.isDirectory()) {
+		throw new AppError(
+			`Expected a .scriv project folder or .scrivx file: ${normalizedPath}`,
+			ErrorCode.INVALID_INPUT,
+			{ path: normalizedPath }
+		);
+	}
+
+	return {
+		projectPath: normalizedPath,
+		scrivxPath: await findScrivxPath(normalizedPath),
+	};
+}
 
 // ============================================================================
 // Document Path Utilities
@@ -622,6 +785,13 @@ export default {
 	SCRIVENER_EXTENSIONS,
 	SCRIVENER_FOLDERS,
 	SCRIVENER_LIMITS,
+
+	// Project path utilities
+	normalizeScrivenerPath,
+	getScrivenerProjectName,
+	getDefaultScrivxPath,
+	findScrivxPath,
+	resolveScrivenerProjectPath,
 
 	// Path utilities
 	getDocumentPath,

--- a/tests/unit/services/project-loader-paths.test.ts
+++ b/tests/unit/services/project-loader-paths.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { ProjectLoader } from '../../../src/services/project-loader.js';
+
+const scrivxContent = '<ScrivenerProject><Binder /></ScrivenerProject>';
+
+describe('ProjectLoader Scrivener path discovery', () => {
+	let tempRoot: string;
+
+	beforeEach(async () => {
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'scrivener-loader-'));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+	});
+
+	it('loads the only .scrivx file when the file name differs from the project folder', async () => {
+		const projectPath = path.join(tempRoot, 'WindowsNovel.scriv');
+		await fs.mkdir(projectPath, { recursive: true });
+		await fs.writeFile(path.join(projectPath, 'Manuscript.scrivx'), scrivxContent);
+
+		const structure = await new ProjectLoader(projectPath).loadProject();
+
+		expect(structure.ScrivenerProject).toBeDefined();
+	});
+
+	it('uses an explicit .scrivx path when one was resolved by the caller', async () => {
+		const projectPath = path.join(tempRoot, 'ExplicitNovel.scriv');
+		const scrivxPath = path.join(projectPath, 'ExplicitNovel.SCRIVX');
+		await fs.mkdir(projectPath, { recursive: true });
+		await fs.writeFile(scrivxPath, scrivxContent);
+
+		const structure = await new ProjectLoader(projectPath, { scrivxPath }).loadProject();
+
+		expect(structure.ScrivenerProject).toBeDefined();
+	});
+});

--- a/tests/unit/utils/scrivener-paths.test.ts
+++ b/tests/unit/utils/scrivener-paths.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+	findScrivxPath,
+	getDefaultScrivxPath,
+	resolveScrivenerProjectPath,
+} from '../../../src/utils/scrivener-utils.js';
+import { ErrorCode } from '../../../src/utils/common.js';
+
+describe('Scrivener project path utilities', () => {
+	let tempRoot: string;
+
+	beforeEach(async () => {
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'scrivener-paths-'));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+	});
+
+	async function createProject(projectName: string, scrivxName = `${projectName}.scrivx`) {
+		const projectPath = path.join(tempRoot, `${projectName}.scriv`);
+		const scrivxPath = path.join(projectPath, scrivxName);
+
+		await fs.mkdir(projectPath, { recursive: true });
+		await fs.writeFile(scrivxPath, '<ScrivenerProject><Binder /></ScrivenerProject>');
+
+		return { projectPath, scrivxPath };
+	}
+
+	it('builds the default .scrivx path from a project folder name with spaces', async () => {
+		const { projectPath } = await createProject('My Novel');
+
+		expect(getDefaultScrivxPath(projectPath)).toBe(path.join(projectPath, 'My Novel.scrivx'));
+	});
+
+	it('resolves a direct .scrivx file to its project directory', async () => {
+		const { projectPath, scrivxPath } = await createProject('Direct Path');
+
+		await expect(resolveScrivenerProjectPath(scrivxPath)).resolves.toEqual({
+			projectPath,
+			scrivxPath,
+		});
+	});
+
+	it('finds a case-different .scrivx file for Windows project folders', async () => {
+		const { projectPath, scrivxPath } = await createProject('CaseTest', 'casetest.SCRIVX');
+
+		await expect(findScrivxPath(projectPath)).resolves.toBe(scrivxPath);
+	});
+
+	it('falls back to a single alternate .scrivx file in the project folder', async () => {
+		const { projectPath, scrivxPath } = await createProject('Container', 'Manuscript.scrivx');
+
+		await expect(findScrivxPath(projectPath)).resolves.toBe(scrivxPath);
+	});
+
+	it('rejects regular files that are not .scrivx projects', async () => {
+		const filePath = path.join(tempRoot, 'notes.txt');
+		await fs.writeFile(filePath, 'not a project');
+
+		await expect(resolveScrivenerProjectPath(filePath)).rejects.toMatchObject({
+			code: ErrorCode.INVALID_INPUT,
+		});
+	});
+});


### PR DESCRIPTION
Closes #9

## Summary
- Adds a shared Scrivener project path resolver that accepts .scriv folders and direct .scrivx files while preserving native Windows drive/backslash paths.
- Teaches ProjectLoader and project data directory validation to discover the real .scrivx file by default name, case-insensitive match, or single-file fallback instead of hard-coding project.scrivx.
- Passes the resolved .scrivx path through open_project and ScrivenerProject so loader, data directory setup, and direct file opens agree.

## Validation
- npm ci --legacy-peer-deps --ignore-scripts --no-audit --no-fund
- npm test -- --runTestsByPath tests/unit/utils/scrivener-paths.test.ts tests/unit/services/project-loader-paths.test.ts --runInBand
- npm run typecheck
- npm run build
- npx prettier --check src/utils/scrivener-utils.ts src/services/project-loader.ts src/scrivener-project.ts src/utils/project-utils.ts src/handlers/project-handlers.ts tests/unit/utils/scrivener-paths.test.ts tests/unit/services/project-loader-paths.test.ts
- git diff --check

Note: plain npm ci is blocked by an existing lockfile peer dependency conflict, so validation used legacy peer dependency resolution.