### PR TITLE
Add opt-in eager skill registration (SCRIVENER_MCP_EAGER_TOOLS)

### DIFF
--- a/src/handlers/skill-registry.ts
+++ b/src/handlers/skill-registry.ts
@@ -191,6 +191,11 @@ export function initializeSkillRegistry(): void {
 	buildMetaTools();
 	// Always activate project skill (need open_project at minimum)
 	activateSkill('project');
+	// Opt-in: register every skill at startup for clients that do not honor
+	// notifications/tools/list_changed (e.g. some desktop / local-agent clients).
+	if (process.env.SCRIVENER_MCP_EAGER_TOOLS === '1') {
+		for (const s of skills) activateSkill(s.name);
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary
Some MCP clients (e.g. Claude Desktop's "Cowork" / local-agent client) do not re-fetch the tool list after a `notifications/tools/list_changed`. With the current progressive loading, skills activated at runtime via `use_skill` (or auto-activated on `open_project`) never become callable on those clients — the whole document/search/analysis surface is unreachable even though `list_skills` reports them as `activated: true`.

This adds an **opt-in** eager mode: when `SCRIVENER_MCP_EAGER_TOOLS=1`, all skills are registered at startup. The token-optimized default (progressive loading) is unchanged.

## Changes
- `src/handlers/skill-registry.ts`: in `initializeSkillRegistry()`, register every skill at startup when `SCRIVENER_MCP_EAGER_TOOLS=1`.

## Testing
- [ ] `npx tsc --noEmit` (type-only change using the existing `skills` array and `activateSkill`)
- [ ] `npm test`
- [x] Verified at runtime on Claude Desktop: registering all skills at startup makes `read_document` / `write_document` etc. callable on a client that doesn't honor `tools/list_changed` (without it, they never appear).

## Related issues
Closes #50.