### PR TITLE
fix(ci): stop masking missing tests with passWithNoTests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm test -- --testTimeout=30000 --passWithNoTests
+        run: npm test -- --testTimeout=30000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm test -- --passWithNoTests
+        run: npm test -- --testTimeout=30000
 
       - name: Publish to npm (provenance)
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Remove `--passWithNoTests` from CI and release workflows so the pipeline fails when Jest finds no tests to run.

## Motivation

Issue #20 reports that CI can exit green even when tests are effectively absent. Maintainer confirmed this is a real correctness bug and invited PRs against the workflow files.

## Changes

- `.github/workflows/ci.yml`: drop `--passWithNoTests` (keep `--testTimeout=30000`)
- `.github/workflows/release.yml`: drop `--passWithNoTests`, add `--testTimeout=30000` for parity with CI

## Tests

- `npm test -- --testTimeout=30000` — 7 suites, 73 tests passed locally

## Notes

- `|| true` / `continue-on-error` are already absent from current workflows; this PR only tightens the remaining `--passWithNoTests` escape hatch.
- `jest.config.js` still ignores pre-existing failing suites (technical debt tracked separately).

Fixes #20