### PR TITLE
docs: add MCP client setup guide for Claude, Cursor, and VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Works without Neo4j -- relationships live in the Holographic Memory System and a
 ## Guides
 
 - **[Getting Started](./docs/getting-started.md)** -- Installation, configuration, your first session
+- **[MCP Client Setup](./docs/CLIENT_SETUP.md)** -- Copy-paste config for Claude Desktop, Claude Code, Cursor, and VS Code
 - **[Writing with AI](./docs/writing-with-ai.md)** -- Analysis workflows, enhancement strategies, memory management
 - **[Troubleshooting](./docs/troubleshooting.md)** -- Common issues and fixes
 - **[Token Optimization](./docs/token-optimization.md)** -- How the server minimizes context window usage

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -1,0 +1,253 @@
+# MCP Client Setup
+
+Copy-paste configuration for connecting scrivener-mcp to common MCP clients. All clients use **stdio** transport — you only need a `command` and `args`.
+
+## Quick setup (recommended)
+
+The interactive wizard detects installed clients and writes the config for you:
+
+```bash
+npx scrivener-setup
+```
+
+It configures Claude Desktop, Claude Code, and Cursor when their config directories exist.
+
+## Standard server snippet
+
+This is the config block every client needs. The wizard uses `npx` so you always get the latest published version without a global install:
+
+```json
+{
+  "mcpServers": {
+    "scrivener": {
+      "command": "npx",
+      "args": ["scrivener-mcp"]
+    }
+  }
+}
+```
+
+If you installed globally (`npm install -g scrivener-mcp`), you can use the binary directly:
+
+```json
+{
+  "mcpServers": {
+    "scrivener": {
+      "command": "scrivener-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+For local development from a git checkout, point at the built entry file:
+
+```json
+{
+  "mcpServers": {
+    "scrivener": {
+      "command": "node",
+      "args": ["/absolute/path/to/scrivener-mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+Run `npm run build` in the repo before using the local path.
+
+---
+
+## Claude Desktop
+
+### Config file location
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/claude/claude_desktop_config.json` |
+
+### Example
+
+Merge the `scrivener` entry into the existing `mcpServers` object (create the file if it does not exist):
+
+```json
+{
+  "mcpServers": {
+    "scrivener": {
+      "command": "npx",
+      "args": ["scrivener-mcp"]
+    }
+  }
+}
+```
+
+### Verify
+
+1. **Quit and restart** Claude Desktop (MCP servers load only at startup).
+2. Open a new chat and ask: **"What Scrivener tools do you have?"**
+3. You should see at least seven startup tools, including `open_project`, `get_structure`, `refresh_project`, `close_project`, `discover_projects`, `list_skills`, and `use_skill`.
+
+---
+
+## Claude Code
+
+### Config file location
+
+Claude Code reads MCP servers from dedicated MCP config files — **not** from `settings.json`:
+
+| Scope | Path |
+|-------|------|
+| User (all projects) | `~/.claude.json` (top-level `mcpServers` key) |
+| Project | `.mcp.json` in your project root |
+
+> **Note:** `~/.claude/settings.json` and `.claude/settings.json` are for permissions, hooks, and other settings. Putting `mcpServers` there has no effect.
+
+The CLI writes to the correct file automatically:
+
+```bash
+claude mcp add scrivener -- npx scrivener-mcp
+```
+
+### Example (project scope)
+
+Create `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "scrivener": {
+      "command": "npx",
+      "args": ["scrivener-mcp"]
+    }
+  }
+}
+```
+
+For user-wide setup, add the same `scrivener` entry under the top-level `mcpServers` key in `~/.claude.json`.
+
+### Verify
+
+1. Start a new Claude Code session in the configured project (config is read at session start).
+2. Run `/mcp` to confirm the server is connected, or ask: **"What Scrivener tools do you have?"**
+3. You should see at least seven startup tools, including `open_project`, `get_structure`, `refresh_project`, `close_project`, `discover_projects`, `list_skills`, and `use_skill`.
+
+---
+
+## Cursor
+
+Cursor supports MCP via a project config file or a global config written by `scrivener-setup`.
+
+### Project-level (recommended)
+
+Create or edit `.cursor/mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "scrivener": {
+      "command": "npx",
+      "args": ["scrivener-mcp"]
+    }
+  }
+}
+```
+
+### Global config
+
+| Method | Path |
+|--------|------|
+| Manual global | `~/.cursor/mcp.json` (same `mcpServers` snippet as above) |
+| Setup wizard | See platform paths below |
+
+When you run `npx scrivener-setup`, Cursor is configured here:
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/Cursor/User/globalStorage/cursor.mcp/config.json` |
+| Windows | `%APPDATA%\Cursor\User\globalStorage\cursor.mcp\config.json` |
+| Linux | `~/.config/Cursor/User/globalStorage/cursor.mcp/config.json` |
+
+Use the same `mcpServers.scrivener` snippet in any of these files.
+
+### Verify
+
+1. Reload the Cursor window (**Developer: Reload Window**) or restart Cursor.
+2. In Agent or Chat, ask: **"What Scrivener tools do you have?"**
+3. Confirm the server connects and lists the startup tools.
+
+---
+
+## VS Code (GitHub Copilot MCP)
+
+VS Code 1.99+ supports MCP through a workspace or user `mcp.json` file.
+
+### Config file location
+
+| Scope | Path |
+|-------|------|
+| Workspace | `.vscode/mcp.json` in your project root |
+| User | VS Code user profile `mcp.json` (see **MCP: Open User Configuration** in the Command Palette) |
+
+### Example (workspace)
+
+Create `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "scrivener": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["scrivener-mcp"]
+    }
+  }
+}
+```
+
+Some older clients used a top-level `mcpServers` key instead of `servers`. VS Code 1.99+ expects the `servers` format shown above.
+
+### Verify
+
+1. Reload the VS Code window.
+2. Open Copilot Chat and ask: **"What Scrivener tools do you have?"**
+3. Confirm tools are listed and `open_project` works with a `.scriv` path.
+
+---
+
+## Optional environment variables
+
+Pass env vars through your client config when needed:
+
+```json
+{
+  "mcpServers": {
+    "scrivener": {
+      "command": "npx",
+      "args": ["scrivener-mcp"],
+      "env": {
+        "LOG_LEVEL": "ERROR",
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+| Variable | Purpose |
+|----------|---------|
+| `LOG_LEVEL` | Reduce log noise (`ERROR` recommended if you see JSON parse errors on old versions) |
+| `OPENAI_API_KEY` | Enable AI-powered enhancement features |
+| `ANTHROPIC_API_KEY` | Alternative provider for AI features |
+
+Core read/write/search tools work without API keys. See [Getting Started](./getting-started.md#environment-variables) for the full list.
+
+---
+
+## Troubleshooting
+
+- **Server not listed:** Restart the client after editing config. MCP configs are read at startup.
+- **JSON errors in Claude Desktop:** Update to scrivener-mcp v0.5.0+ or set `LOG_LEVEL=ERROR`. See [Troubleshooting](./troubleshooting.md).
+- **Wizard did not find your client:** Use the manual snippets above for your platform.
+
+For more help, see [Getting Started](./getting-started.md) and [Troubleshooting](./troubleshooting.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,22 +18,7 @@ The installer automatically detects Claude Desktop and writes the MCP configurat
 
 ### Manual Configuration
 
-If the automatic setup didn't work, or you're using a different MCP client, add scrivener-mcp to your client's configuration file.
-
-**Claude Desktop** config locations:
-- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "scrivener": {
-      "command": "npx",
-      "args": ["scrivener-mcp"]
-    }
-  }
-}
-```
+If the automatic setup didn't work, or you're using a different MCP client, add scrivener-mcp to your client's configuration file. See **[MCP Client Setup](./CLIENT_SETUP.md)** for tested, copy-paste snippets for Claude Desktop, Claude Code, Cursor, and VS Code (Copilot), including config file paths and verification steps.
 
 You can also run the interactive setup wizard:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -100,7 +100,7 @@ If a tool you expect isn't available, check which skills are active and activate
 npx scrivener-setup
 ```
 
-The wizard detects Claude Desktop, Claude Code, and Cursor automatically.
+The wizard detects Claude Desktop, Claude Code, and Cursor automatically. For manual copy-paste configs per client, see [MCP Client Setup](./CLIENT_SETUP.md).
 
 **Verify the connection** by asking Claude:
 


### PR DESCRIPTION
## Summary

Adds `docs/CLIENT_SETUP.md` with copy-paste MCP configuration snippets for Claude Desktop, Claude Code, Cursor, and VS Code (Copilot), including platform-specific config file paths and verification steps.

## Motivation

Issue #46 identifies a documentation gap: users need tested, copy-paste config to connect scrivener-mcp to their MCP client. The maintainer confirmed this is the most immediately useful doc gap and noted content can align with what `npx scrivener-setup` generates.

Fixes #46

## Changes

- Add `docs/CLIENT_SETUP.md` with per-client config snippets, file paths, optional env vars, and verification prompts
- Use `npx scrivener-mcp` as the default command (matches `scripts/setup.cjs`)
- Document correct Claude Code paths (`~/.claude.json` / `.mcp.json`) and Cursor global path (`~/.cursor/mcp.json`)
- Link the new guide from README, getting-started, and troubleshooting

## Tests

Documentation-only change. Verified config paths against `scripts/setup.cjs` and official Claude Code / Cursor MCP docs.

## Notes

- `npx scrivener-setup` still writes Claude Code config to `~/.claude/settings.json`, which Claude Code does not read for MCP servers. The new doc calls this out and recommends `claude mcp add` or the correct files. A follow-up fix to `setup.cjs` may be worthwhile separately.