### PR TITLE
chore: ignore confidential PROVENANCE.md at the repo level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ scratch/
 
 # Runtime state (job queue, etc.) written next to the server at runtime
 data/
+# Confidential anti-piracy provenance fingerprints — never commit (public repo).
+# Also covered by a global core.excludesFile; pinned here so the guard travels with the repo.
+PROVENANCE.md


### PR DESCRIPTION
`PROVENANCE.md` holds confidential anti-piracy fingerprints (marked *do-not-commit*) but was protected only by a per-machine global `core.excludesFile`. Pin the ignore in the repo so the guard travels with the clone — a `git add -A` from another machine can no longer leak it. The file stays untracked; verified it is not addable without `-f`.