### PR TITLE
test(ai): deterministic parsing coverage for AISemanticExtractor

### DIFF
--- a/tests/unit/services/ai/ai-semantic-extractor.test.ts
+++ b/tests/unit/services/ai/ai-semantic-extractor.test.ts
@@ -4,8 +4,37 @@
  * not parity with the old LangChain extractor.
  */
 
-import { AISemanticExtractor } from '../../../../src/services/ai/ai-semantic-extractor.js';
+import {
+	AISemanticExtractor,
+	type ExtractedEntity,
+} from '../../../../src/services/ai/ai-semantic-extractor.js';
 import { AIClient } from '../../../../src/services/ai/ai-client.js';
+
+/**
+ * Stub the AIClient so the parsing/coercion path runs deterministically without
+ * a key or network — this is the bug-prone code, and it is otherwise only covered
+ * by the key-gated live tests (skipped in CI).
+ */
+function stub(reply: string | (() => string)) {
+	let calls = 0;
+	let lastPrompt = '';
+	const ai = {
+		provider: 'anthropic',
+		chat: async (prompt: string) => {
+			calls += 1;
+			lastPrompt = prompt;
+			return typeof reply === 'function' ? reply() : reply;
+		},
+	} as unknown as AIClient;
+	return { ex: new AISemanticExtractor(ai), calls: () => calls, lastPrompt: () => lastPrompt };
+}
+
+const entity = (name: string): ExtractedEntity => ({
+	name,
+	type: 'character',
+	context: '',
+	mentions: 1,
+});
 
 describe('AISemanticExtractor', () => {
 	it('returns empty for empty text without calling the model', async () => {
@@ -50,5 +79,86 @@ describe('AISemanticExtractor', () => {
 				expect(rels[0].entity1.length).toBeGreaterThan(0);
 			}
 		}, 30000);
+	});
+});
+
+describe('AISemanticExtractor — deterministic parsing (stubbed client)', () => {
+	describe('extractEntities', () => {
+		it('parses a fenced JSON array and normalizes fields', async () => {
+			const { ex } = stub(
+				'```json\n[{"name":"  Mara ","type":"CHARACTER","context":"captain","mentions":3}]\n```'
+			);
+			const [e] = await ex.extractEntities('text');
+			expect(e).toEqual({ name: 'Mara', type: 'character', context: 'captain', mentions: 3 });
+		});
+
+		it('coerces an unknown type to object and drops nameless entries', async () => {
+			const { ex } = stub(
+				'[{"name":"X","type":"alien"},{"type":"character"},{"name":"   "}]'
+			);
+			const out = await ex.extractEntities('text');
+			expect(out).toEqual([{ name: 'X', type: 'object', context: '', mentions: 1 }]);
+		});
+
+		it('floors and defaults the mention count', async () => {
+			const { ex } = stub(
+				'[{"name":"A","mentions":2.9},{"name":"B","mentions":-4},{"name":"C","mentions":"x"}]'
+			);
+			expect((await ex.extractEntities('text')).map((e) => e.mentions)).toEqual([2, 1, 1]);
+		});
+
+		it('returns [] for a non-array reply', async () => {
+			const { ex } = stub('{"not":"an array"}');
+			expect(await ex.extractEntities('text')).toEqual([]);
+		});
+
+		it('throws when the reply contains no JSON (current contract)', async () => {
+			const { ex } = stub('I could not find anything to extract.');
+			await expect(ex.extractEntities('text')).rejects.toThrow();
+		});
+	});
+
+	describe('analyzeRelationships', () => {
+		it('does not call the model for fewer than two entities', async () => {
+			const { ex, calls } = stub(() => {
+				throw new Error('chat must not be called');
+			});
+			expect(await ex.analyzeRelationships([entity('A')])).toEqual([]);
+			expect(calls()).toBe(0);
+		});
+
+		it('parses and clamps relationship strength, coercing bad types', async () => {
+			const { ex } = stub(
+				'[{"entity1":"A","entity2":"B","relationship":"knows","strength":1.7,"type":"weird"},' +
+					'{"entity1":"A","entity2":"B","relationship":"sees","strength":-2,"type":"location"},' +
+					'{"entity1":"A","entity2":"B","relationship":"x","strength":"nan"}]'
+			);
+			const out = await ex.analyzeRelationships([entity('A'), entity('B')]);
+			expect(out.map((r) => r.strength)).toEqual([1, 0, 0.5]);
+			expect(out[0].type).toBe('character');
+			expect(out[1].type).toBe('location');
+		});
+
+		it('drops relationships missing a side or the relationship text', async () => {
+			const { ex } = stub(
+				'[{"entity1":"A","entity2":"B"},{"entity1":"A","relationship":"r"},{"entity2":"B","relationship":"r"}]'
+			);
+			expect(await ex.analyzeRelationships([entity('A'), entity('B')])).toEqual([]);
+		});
+	});
+
+	describe('generateWithTemplate', () => {
+		it('returns the model content and prefers customPrompt', async () => {
+			const { ex, lastPrompt } = stub('OUTPUT');
+			const r = await ex.generateWithTemplate('task', 'fallback', { customPrompt: 'CUSTOM' });
+			expect(r).toEqual({ content: 'OUTPUT' });
+			expect(lastPrompt()).toBe('CUSTOM');
+		});
+
+		it('falls back to the plain prompt when no customPrompt is given', async () => {
+			const { ex, lastPrompt } = stub('OUTPUT');
+			await ex.generateWithTemplate('task', 'fallback');
+			expect(lastPrompt()).toBe('fallback');
+		});
 	});
 });


### PR DESCRIPTION
The extractor's defensive JSON parsing/coercion — its whole point — was covered only by **key-gated live tests that skip in CI**, so the most bug-prone code ran nowhere offline (the same 'CI green ≠ verified' gap noted elsewhere in the stack).

Adds 10 deterministic tests via a stubbed `AIClient` (no key, no network):
- fenced-JSON parse + field normalization (trim, lowercase type, floor mentions)
- unknown entity `type` → `object`; nameless entries dropped
- mention count floored / defaulted; non-array reply → `[]`; no-JSON reply throws (pins current contract)
- `analyzeRelationships`: <2-entity no-model-call guard, strength clamped to 0–1, malformed-type coercion, missing-side drop
- `generateWithTemplate`: returns content, prefers `customPrompt`

All pass; `tsc --noEmit` clean. No production code changed.