### PR TITLE
fix(ai): resilient extractor parsing + source-aware relationships + wire into semantic layer

### DIFF
--- a/src/handlers/database/langchain-semantic-layer.ts
+++ b/src/handlers/database/langchain-semantic-layer.ts
@@ -1,6 +1,6 @@
 import type { DatabaseService } from './database-service.js';
 import { EnhancedLangChainService } from '../../services/ai/langchain-service-enhanced.js';
-import { AdvancedLangChainFeatures } from '../../services/ai/langchain-advanced-features.js';
+import { AISemanticExtractor } from '../../services/ai/ai-semantic-extractor.js';
 import { LangChainHMSVectorStore } from '../../services/ai/hms-vector-store.js';
 import { OpenAIEmbeddings } from '@langchain/openai';
 import { Document as LangchainDocument } from '@langchain/core/documents';
@@ -136,7 +136,7 @@ export interface EntityAnalysis {
 export class SemanticDatabaseLayer {
 	private databaseService: DatabaseService;
 	private langchain: EnhancedLangChainService;
-	private advanced: AdvancedLangChainFeatures;
+	private extractor: AISemanticExtractor;
 	private vectorStore: LangChainHMSVectorStore;
 	private logger: ReturnType<typeof getLogger>;
 	private knowledgeGraphCache: KnowledgeGraph | null = null;
@@ -146,7 +146,7 @@ export class SemanticDatabaseLayer {
 	constructor(databaseService: DatabaseService) {
 		this.databaseService = databaseService;
 		this.langchain = new EnhancedLangChainService();
-		this.advanced = new AdvancedLangChainFeatures();
+		this.extractor = new AISemanticExtractor();
 		const embeddings = new OpenAIEmbeddings();
 		this.vectorStore = new LangChainHMSVectorStore(embeddings);
 		this.logger = getLogger('SemanticDatabaseLayer');
@@ -473,7 +473,7 @@ Provide a brief, clear explanation (1-2 sentences) of why this document matches 
 	> {
 		try {
 			const combinedContent = results.map((r) => r.content).join('\n\n');
-			const entities = await this.advanced.extractEntities(combinedContent);
+			const entities = await this.extractor.extractEntities(combinedContent);
 
 			return entities.map((entity) => ({
 				name: entity.name,
@@ -521,13 +521,14 @@ Provide a brief, clear explanation (1-2 sentences) of why this document matches 
 
 		try {
 			const combinedContent = results.map((r) => r.content).join('\n\n');
-			const relationships = await this.advanced.analyzeRelationships(
+			const relationships = await this.extractor.analyzeRelationships(
 				entities.map((e) => ({
 					name: e.name,
 					type: e.type as 'character' | 'location' | 'organization' | 'event' | 'object',
 					context: combinedContent,
 					mentions: 1,
-				}))
+				})),
+				combinedContent
 			);
 
 			return relationships.map((rel) => ({
@@ -643,7 +644,7 @@ Format as JSON: {summary, themes: [], patterns: [], suggestions: []}`;
 
 			try {
 				// Extract entities from document
-				const entities = await this.advanced.extractEntities(doc.content);
+				const entities = await this.extractor.extractEntities(doc.content);
 
 				// Create nodes for entities
 				for (const entity of entities) {
@@ -673,7 +674,7 @@ Format as JSON: {summary, themes: [], patterns: [], suggestions: []}`;
 
 				// Extract relationships
 				if (entities.length > 1) {
-					const relationships = await this.advanced.analyzeRelationships(
+					const relationships = await this.extractor.analyzeRelationships(
 						entities.map((e) => ({
 							name: e.name,
 							type: e.type as
@@ -684,7 +685,8 @@ Format as JSON: {summary, themes: [], patterns: [], suggestions: []}`;
 								| 'object',
 							context: doc.content || '',
 							mentions: 1,
-						}))
+						})),
+						doc.content || ''
 					);
 
 					for (const rel of relationships) {
@@ -925,7 +927,7 @@ Return only the numeric score.`;
 	): Promise<EntityAnalysis['relationships']> {
 		try {
 			const contexts = mentions.map((m) => m.context).join('\n\n');
-			const relationships = await this.advanced.analyzeRelationships([
+			const relationships = await this.extractor.analyzeRelationships([
 				{
 					name: entity,
 					type: 'object',

--- a/src/services/ai/ai-semantic-extractor.ts
+++ b/src/services/ai/ai-semantic-extractor.ts
@@ -6,7 +6,6 @@
 
 import { AIClient } from './ai-client.js';
 import { getLogger } from '../../core/logger.js';
-import { ErrorCode, createError } from '../../utils/common.js';
 
 const logger = getLogger('ai-semantic-extractor');
 
@@ -29,14 +28,30 @@ export interface ExtractedRelationship {
 
 const ENTITY_TYPES: EntityType[] = ['character', 'location', 'organization', 'event', 'object'];
 
+/**
+ * Best-effort parse of a model reply to JSON. Returns null (never throws) when the
+ * reply has no JSON or is malformed, so a flaky completion degrades to an empty
+ * extraction instead of crashing the pipeline feeding the semantic layer.
+ */
 function parseJsonValue(raw: string): unknown {
 	const withoutFences = raw.replace(/```(?:json)?/gi, '').trim();
 	const firstBrace = withoutFences.search(/[[{]/);
 	if (firstBrace === -1) {
-		throw createError(ErrorCode.INVALID_FORMAT, null, 'Model reply contained no JSON');
+		logger.warn('Model reply contained no JSON; treating as empty result', {
+			preview: raw.slice(0, 120),
+		});
+		return null;
 	}
 	const lastBrace = Math.max(withoutFences.lastIndexOf(']'), withoutFences.lastIndexOf('}'));
-	return JSON.parse(withoutFences.slice(firstBrace, lastBrace + 1));
+	try {
+		return JSON.parse(withoutFences.slice(firstBrace, lastBrace + 1));
+	} catch (error) {
+		logger.warn('Model reply was not valid JSON; treating as empty result', {
+			preview: raw.slice(0, 120),
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return null;
+	}
 }
 
 function clamp01(value: unknown): number {
@@ -97,9 +112,15 @@ export class AISemanticExtractor {
 		return entities;
 	}
 
-	async analyzeRelationships(entities: ExtractedEntity[]): Promise<ExtractedRelationship[]> {
+	async analyzeRelationships(
+		entities: ExtractedEntity[],
+		sourceText?: string
+	): Promise<ExtractedRelationship[]> {
 		if (entities.length < 2) return [];
-		const context = entities[0]?.context ?? '';
+		// Prefer the actual source passage; fall back to the first entity's context
+		// phrase only when no passage is supplied. Inferring links from names alone
+		// loses the very text that establishes them.
+		const context = (sourceText?.trim() || entities[0]?.context || '').slice(0, 4000);
 		const names = entities.map((e) => e.name).join(', ');
 
 		const prompt =

--- a/tests/unit/services/ai/ai-semantic-extractor.test.ts
+++ b/tests/unit/services/ai/ai-semantic-extractor.test.ts
@@ -112,9 +112,14 @@ describe('AISemanticExtractor — deterministic parsing (stubbed client)', () =>
 			expect(await ex.extractEntities('text')).toEqual([]);
 		});
 
-		it('throws when the reply contains no JSON (current contract)', async () => {
+		it('returns [] (does not throw) when the reply contains no JSON', async () => {
 			const { ex } = stub('I could not find anything to extract.');
-			await expect(ex.extractEntities('text')).rejects.toThrow();
+			expect(await ex.extractEntities('text')).toEqual([]);
+		});
+
+		it('returns [] (does not throw) when the JSON is malformed', async () => {
+			const { ex } = stub('[{"name":"A", broken');
+			expect(await ex.extractEntities('text')).toEqual([]);
 		});
 	});
 
@@ -144,6 +149,12 @@ describe('AISemanticExtractor — deterministic parsing (stubbed client)', () =>
 				'[{"entity1":"A","entity2":"B"},{"entity1":"A","relationship":"r"},{"entity2":"B","relationship":"r"}]'
 			);
 			expect(await ex.analyzeRelationships([entity('A'), entity('B')])).toEqual([]);
+		});
+
+		it('puts the source passage in the prompt when provided', async () => {
+			const { ex, lastPrompt } = stub('[]');
+			await ex.analyzeRelationships([entity('A'), entity('B')], 'A betrayed B at dawn.');
+			expect(lastPrompt()).toContain('A betrayed B at dawn.');
 		});
 	});
 


### PR DESCRIPTION
Resolves the three review follow-ups from #59.

**1. Resilient parsing (was: throw vs []).** `parseJsonValue` returns `null` and logs a warning on a no-JSON or malformed reply instead of throwing, so a flaky completion degrades to an empty extraction rather than crashing the semantic pipeline. Both callers already guard `!Array.isArray`. Removed the now-dead `createError` import.

**2. Source-aware relationships.** `analyzeRelationships(entities, sourceText?)` reasons over the actual passage (capped 4k chars) when given, instead of only `entities[0].context`. Backward compatible; new test asserts the passage reaches the prompt.

**3. Wired into the semantic layer.** `AISemanticExtractor` now backs `SemanticDatabaseLayer`, **fully replacing `AdvancedLangChainFeatures`** for entity/relationship extraction, source text threaded through. `generateWithTemplate` deliberately stays on `EnhancedLangChainService` — its RAG context injection isn't replicated by the lean version, so swapping it would silently drop context.

Build + `tsc --noEmit` clean; full suite **106 pass / 0 fail**.