### PR TITLE
feat(ai): targeted RAG context for the two truncated generation sites

### DIFF
--- a/src/handlers/database/retrieved-context.ts
+++ b/src/handlers/database/retrieved-context.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure formatting of vector-store hits into a grounding context block. Kept in its
+ * own module (with only a minimal structural type, no HMS imports) so it can be unit
+ * tested without pulling in the heavy holographic-memory chain.
+ */
+
+/** Minimal structural shape of a vector hit — compatible with HMSDocument. */
+export interface RetrievedDoc {
+	pageContent: string;
+	metadata?: Record<string, unknown>;
+}
+
+export function formatRetrievedContext(
+	hits: Array<[RetrievedDoc, number]>,
+	perDocChars = 600
+): string {
+	return hits
+		.map(([doc]) => {
+			const title = (doc.metadata?.title as string) || 'Document';
+			const content = (doc.pageContent || '').slice(0, perDocChars);
+			return content ? `[${title}]: ${content}` : '';
+		})
+		.filter((block) => block.length > 0)
+		.join('\n\n---\n\n');
+}

--- a/src/handlers/database/semantic-database-layer.ts
+++ b/src/handlers/database/semantic-database-layer.ts
@@ -4,6 +4,7 @@ import { HMSVectorStore, type HMSDocument } from '../../services/ai/hms-vector-s
 import type { ScrivenerDocument } from '../../types/index.js';
 import { getLogger } from '../../core/logger.js';
 import { toDatabaseError } from '../../utils/database.js';
+import { formatRetrievedContext } from './retrieved-context.js';
 
 export interface VectorSearchResult {
 	id: string;
@@ -420,6 +421,23 @@ Return as JSON with fields: intent, entities, relationships, temporal, filters`;
 		return Array.from(resultMap.values()).sort((a, b) => b.relevanceScore - a.relevanceScore);
 	}
 
+	/**
+	 * Retrieve fuller relevant passages from the vector store to ground a generation
+	 * prompt. Resilient: returns '' on empty or error so a retrieval failure never
+	 * breaks the calling feature.
+	 */
+	private async retrieveContext(query: string, topK = 5): Promise<string> {
+		try {
+			const hits = await this.vectorStore.similaritySearchWithScore(query, topK);
+			return formatRetrievedContext(hits);
+		} catch (error) {
+			this.logger.warn('Context retrieval failed; proceeding without it', {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return '';
+		}
+	}
+
 	private async generateResultExplanation(
 		result: { title: string; content: string; relevanceScore: number },
 		query: { intent: string; entities: string[] }
@@ -431,7 +449,7 @@ Query Entities: ${query.entities.join(', ')}
 Document: "${result.title}"
 Relevance Score: ${result.relevanceScore.toFixed(2)}
 
-Content Preview: ${result.content.slice(0, 200)}...
+Content: ${result.content.slice(0, 800)}${result.content.length > 800 ? '...' : ''}
 
 Provide a brief, clear explanation (1-2 sentences) of why this document matches the query.`;
 
@@ -565,9 +583,15 @@ Provide:
 Format as JSON: {summary, themes: [], patterns: [], suggestions: []}`;
 
 		try {
+			// Ground the cross-document synthesis with fuller retrieved passages; the
+			// inline summary above truncates each result to 100 chars.
+			const retrieved = await this.retrieveContext(query);
+			const groundedPrompt = retrieved
+				? `${prompt}\n\nAdditional relevant excerpts:\n${retrieved}`
+				: prompt;
 			const result = await this.extractor.generateWithTemplate('insight_generation', query, {
 				format: 'json',
-				customPrompt: prompt,
+				customPrompt: groundedPrompt,
 			});
 
 			const insights = JSON.parse(result.content);

--- a/tests/unit/handlers/database/semantic-context.test.ts
+++ b/tests/unit/handlers/database/semantic-context.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Behavior tests for the retrieved-context formatter that grounds the semantic
+ * layer's generation prompts. Pure and deterministic — no vector store needed.
+ */
+
+import {
+	formatRetrievedContext,
+	type RetrievedDoc,
+} from '../../../../src/handlers/database/retrieved-context.js';
+
+const hit = (pageContent: string, title?: string): [RetrievedDoc, number] => [
+	{ pageContent, metadata: title ? { title } : {} },
+	0.9,
+];
+
+describe('formatRetrievedContext', () => {
+	it('labels passages by title and joins them with separators', () => {
+		const out = formatRetrievedContext([hit('alpha', 'Ch1'), hit('beta', 'Ch2')]);
+		expect(out).toBe('[Ch1]: alpha\n\n---\n\n[Ch2]: beta');
+	});
+
+	it('defaults the label to Document when a hit has no title', () => {
+		expect(formatRetrievedContext([hit('x')])).toBe('[Document]: x');
+	});
+
+	it('caps each passage to perDocChars', () => {
+		const out = formatRetrievedContext([hit('y'.repeat(100), 'T')], 10);
+		expect(out).toBe(`[T]: ${'y'.repeat(10)}`);
+	});
+
+	it('drops empty-content hits and returns empty for no hits', () => {
+		expect(formatRetrievedContext([hit('', 'T')])).toBe('');
+		expect(formatRetrievedContext([])).toBe('');
+	});
+});


### PR DESCRIPTION
Completes the RAG-context port from the lean `generateWithTemplate` migration — **targeted, not blanket** (per review: the other 6 call sites already pass precise caller-built context, so generic RAG would inject noise there).

**insight_generation** — cross-document synthesis that truncates each result to 100 chars. Now prepends vector-retrieved excerpts via a new resilient `retrieveContext` helper over the existing `vectorStore` (empty/error → no context, never breaks the call).

**result_explanation** — explains *one specific* document, truncated to 200 chars. A vector search here is semantically wrong (it would retrieve *other* docs); the correct richer context is fuller content of that doc itself (200 → 800 chars).

The pure formatter lives in a new `retrieved-context.ts` (minimal structural type, no HMS imports) so it's unit-testable without dragging in the holographic-memory chain — which otherwise breaks ts-jest with a top-level-await error.

`tsc --noEmit` clean; full suite **122 pass / 0 fail** (+4 new formatter tests).