### PR TITLE
Apply compile-format section layouts to structured compile

### DIFF
--- a/src/handlers/compilation-handlers.ts
+++ b/src/handlers/compilation-handlers.ts
@@ -145,6 +145,15 @@ export const compileDocumentsHandler: ToolDefinition = {
 					'For mode "structured": include documents whose "Include in Compile" flag is off. ' +
 					'Default false (excluded documents are omitted, matching Scrivener).',
 			},
+			compileFormatId: {
+				type: 'string',
+				description:
+					'For mode "structured": id of a compile format from get_compile_settings. When given, ' +
+					"sections whose resolved Section Type maps to one of that format's recognized standard " +
+					"layouts (title visibility, chapter auto-numbering, page breaks) use that layout's " +
+					'behavior instead of includeTitles/sceneSeparator. Custom or unrecognized layouts fall ' +
+					'back to the generic behavior — this is best-effort, not full Scrivener compile fidelity.',
+			},
 			hierarchical: {
 				type: 'boolean',
 				description: 'Preserve the binder folder hierarchy as headings. Default false.',
@@ -240,6 +249,7 @@ export const compileDocumentsHandler: ToolDefinition = {
 				sceneSeparator: getOptionalStringArg(args, 'sceneSeparator') ?? '',
 				includeTitles: (args.includeTitles as boolean) ?? true,
 				includeExcluded: (args.includeExcluded as boolean) ?? false,
+				compileFormatId: getOptionalStringArg(args, 'compileFormatId'),
 			});
 			return formatCompileResult(text, documentsToCompile.length, format);
 		}

--- a/src/scrivener-project.ts
+++ b/src/scrivener-project.ts
@@ -498,6 +498,8 @@ export class ScrivenerProject {
 			sceneSeparator?: string;
 			includeTitles?: boolean;
 			includeExcluded?: boolean;
+			/** Apply this compile format's standard section-layout behavior (see CompilationService.compileStructured). */
+			compileFormatId?: string;
 		} = {}
 	): Promise<string> {
 		// Walk the nested binder tree so heading depth comes from actual structure,
@@ -532,16 +534,31 @@ export class ScrivenerProject {
 						});
 					}
 				}
-				entries.push({ title: node.title, content, depth, isFolder: !isText });
+				entries.push({
+					title: node.title,
+					content,
+					depth,
+					isFolder: !isText,
+					sectionTypeId: node.sectionTypeId,
+				});
 				if (node.children?.length) await walk(node.children, depth + 1);
 			}
 		};
 		await walk(roots, 1);
 
+		let sectionLayouts: Record<string, string> | undefined;
+		if (options.compileFormatId) {
+			const metadata = await this.getCompileMetadata().catch(() => null);
+			sectionLayouts = metadata?.compileFormats.find(
+				(f) => f.id === options.compileFormatId
+			)?.sectionLayouts;
+		}
+
 		return this.compilationService.compileStructured(entries, {
 			outputFormat: options.outputFormat ?? 'text',
 			sceneSeparator: options.sceneSeparator ?? '',
 			includeTitles: options.includeTitles ?? true,
+			sectionLayouts,
 		});
 	}
 

--- a/src/services/compilation-service.ts
+++ b/src/services/compilation-service.ts
@@ -6,6 +6,7 @@ import { DOCUMENT_TYPES } from '../core/constants.js';
 import { createError, ErrorCode } from '../core/errors.js';
 import { getLogger } from '../core/logger.js';
 import { getAccurateWordCount } from '../utils/text-metrics.js';
+import { classifyLayout } from './compile-settings.js';
 import type {
 	DocumentInfo,
 	ProjectMetadata,
@@ -33,6 +34,8 @@ export interface StructuredEntry {
 	/** 1-based binder depth, used as the heading level (top-level = 1). */
 	depth: number;
 	isFolder: boolean;
+	/** Resolved Section Type ID (ScrivenerDocument.sectionTypeId), if any. */
+	sectionTypeId?: string;
 }
 
 export interface StructuredCompileOptions {
@@ -41,6 +44,14 @@ export interface StructuredCompileOptions {
 	sceneSeparator?: string;
 	/** Emit each document's title as a heading. Default true. */
 	includeTitles?: boolean;
+	/**
+	 * A compile format's section-type -> layout-ID map (CompileFormat.sectionLayouts).
+	 * When given, entries whose sectionTypeId resolves to a recognized standard
+	 * layout (see classifyLayout) get that layout's title/numbering/page-break
+	 * behavior instead of the generic includeTitles/sceneSeparator behavior.
+	 * Omit for today's unchanged, format-agnostic compile.
+	 */
+	sectionLayouts?: Record<string, string>;
 }
 
 export interface SearchOptions {
@@ -124,12 +135,19 @@ export class CompilationService {
 	 * a structured manuscript: folder titles become headings at their binder depth,
 	 * document titles optionally become headings, and a scene separator is inserted
 	 * between consecutive sibling documents. Unlike compile_documents' AI path this
-	 * needs no API key and is fully reproducible. It reflects the *binder*
-	 * structure; it does not reproduce Scrivener's compile-format section layouts
-	 * (those definitions are not stored in the project — see docs/scrivener-format.md).
+	 * needs no API key and is fully reproducible. With no `sectionLayouts` given it
+	 * reflects only the *binder* structure, generic across every compile format.
+	 * Passing a format's sectionLayouts applies that format's standard-layout
+	 * title/numbering/page-break behavior per entry (see classifyLayout) - still
+	 * best-effort, since the layouts' full rules live outside the project file.
 	 */
 	compileStructured(entries: StructuredEntry[], options: StructuredCompileOptions = {}): string {
-		const { outputFormat = 'text', sceneSeparator = '', includeTitles = true } = options;
+		const {
+			outputFormat = 'text',
+			sceneSeparator = '',
+			includeTitles = true,
+			sectionLayouts,
+		} = options;
 
 		const heading = (title: string, depth: number): string => {
 			const level = Math.min(Math.max(depth, 1), 6);
@@ -141,6 +159,10 @@ export class CompilationService {
 			return title.toUpperCase();
 		};
 
+		const pageBreak = (): string =>
+			outputFormat === 'html' ? '<div style="page-break-before:always"></div>' : '\f';
+
+		let chapterNumber = 0;
 		const parts: string[] = [];
 		let prevWasDocument = false;
 		for (const entry of entries) {
@@ -150,9 +172,24 @@ export class CompilationService {
 				prevWasDocument = false;
 				continue;
 			}
-			if (prevWasDocument && sceneSeparator) parts.push(sceneSeparator);
+
+			// Only override the generic behavior when this entry actually resolves to a
+			// layout - an entry with no sectionTypeId isn't "AS-IS", it's unknown, and
+			// should keep the generic includeTitles/sceneSeparator behavior.
+			const layoutId = entry.sectionTypeId
+				? sectionLayouts?.[entry.sectionTypeId]
+				: undefined;
+			const layout = layoutId ? classifyLayout(layoutId) : undefined;
+
+			if (layout?.pageBreakBefore) parts.push(pageBreak());
+			else if (prevWasDocument && sceneSeparator) parts.push(sceneSeparator);
+
 			const seg: string[] = [];
-			if (includeTitles && entry.title) seg.push(heading(entry.title, level));
+			const titleVisible = layout ? layout.titleVisible : includeTitles && !!entry.title;
+			if (titleVisible) {
+				const title = layout?.numbered ? `Chapter ${++chapterNumber}` : entry.title;
+				seg.push(heading(title, level));
+			}
 			const body = entry.content.trim();
 			if (body) seg.push(body);
 			if (seg.length > 0) parts.push(seg.join('\n\n'));

--- a/src/services/compile-settings.ts
+++ b/src/services/compile-settings.ts
@@ -46,8 +46,57 @@ export interface CompileFormat {
 	font?: string;
 	/** Number of section-type → layout assignments this format defines. */
 	sectionLayoutCount: number;
+	/** Section-type ID -> layout ID, as assigned by this format. */
+	sectionLayouts: Record<string, string>;
 	/** True when the format injects default front/back matter. */
 	hasFrontMatter: boolean;
+}
+
+/**
+ * How a layout affects compiled output. Scrivener's project files only ever
+ * store a layout *ID* (see CompileFormat.sectionLayouts); the layout's actual
+ * rules (title format, separators, page breaks) live in Scrivener's own
+ * format-preset files, outside the .scriv package, so they can't be read from
+ * project data at all. This recognizes the handful of standard layout IDs
+ * that Scrivener's built-in format presets use consistently (visible by name,
+ * not a GUID) and gives them a reasonable, documented interpretation. Any
+ * other ID - a custom layout, or one from a preset not covered here - is
+ * unclassifiable and returns the same neutral defaults as "no layout".
+ */
+export interface LayoutBehavior {
+	/** Show the document's title before its text. */
+	titleVisible: boolean;
+	/** Render the title as "Chapter <n>" with an auto-incrementing counter. */
+	numbered: boolean;
+	/** Start this section on a new page. */
+	pageBreakBefore: boolean;
+}
+
+const NEUTRAL_LAYOUT: LayoutBehavior = {
+	titleVisible: false,
+	numbered: false,
+	pageBreakBefore: false,
+};
+
+const STANDARD_LAYOUTS: Record<string, LayoutBehavior> = {
+	'AS-IS': NEUTRAL_LAYOUT,
+	'TEXT-SECTION': NEUTRAL_LAYOUT,
+	'TEXT-WITH-HEADER': { titleVisible: true, numbered: false, pageBreakBefore: false },
+	'CHAPTER-NUMBER': { titleVisible: true, numbered: true, pageBreakBefore: true },
+	'NEW-PAGE-HEADER': { titleVisible: true, numbered: false, pageBreakBefore: true },
+};
+
+/**
+ * Classify a layout ID into its formatting behavior. Returns undefined for an
+ * unrecognized ID (a custom layout, or one from a preset not covered above) -
+ * distinct from AS-IS/TEXT-SECTION, which are recognized and genuinely
+ * neutral. Callers should treat undefined as "unknown" and fall back to
+ * their own default, not silently apply neutral (e.g. hiding a title the
+ * user's own generic settings would have shown).
+ */
+export function classifyLayout(layoutId: string | undefined): LayoutBehavior | undefined {
+	if (!layoutId) return undefined;
+	return STANDARD_LAYOUTS[layoutId.toUpperCase()];
 }
 
 /** Aggregated, read-only view of a project's compile and taxonomy settings. */
@@ -136,10 +185,18 @@ export async function parseCompileXml(xml: string): Promise<{
 	const formats = asArray(asRecord(root.FormatSettings).Format).map((raw): CompileFormat => {
 		const fmt = asRecord(raw);
 		const layouts = asArray(asRecord(fmt.SectionLayouts).Type);
+		const sectionLayouts: Record<string, string> = {};
+		for (const layout of layouts) {
+			const rec = asRecord(layout);
+			const sectionTypeId = asString(rec.ID);
+			const layoutId = textOf(layout);
+			if (sectionTypeId && layoutId) sectionLayouts[sectionTypeId] = layoutId;
+		}
 		return {
 			id: asString(fmt.ID) ?? '',
 			font: asString(fmt.Font),
 			sectionLayoutCount: layouts.length,
+			sectionLayouts,
 			hasFrontMatter: 'FrontAndBackMatter' in fmt,
 		};
 	});

--- a/src/services/document-manager.ts
+++ b/src/services/document-manager.ts
@@ -902,7 +902,12 @@ export class DocumentManager {
 			documents.push(doc);
 			if (item.Children?.BinderItem) {
 				doc.children = [];
-				this.buildDocumentTree(item.Children, doc.children, prefix || `${item.Title}/`);
+				this.buildDocumentTree(
+					item.Children,
+					doc.children,
+					prefix || `${item.Title}/`,
+					this.childDefaultOf(item) ?? doc.sectionTypeId
+				);
 			}
 		}
 
@@ -952,22 +957,30 @@ export class DocumentManager {
 	 * Recursively append an item and all its descendants to a flat list,
 	 * threading the folder path so each document's path reflects its ancestry.
 	 */
-	private collectDocuments(item: BinderItem, parentPath: string, out: ScrivenerDocument[]): void {
-		out.push(this.binderItemToDocument(item, parentPath));
+	private collectDocuments(
+		item: BinderItem,
+		parentPath: string,
+		out: ScrivenerDocument[],
+		inheritedSectionType?: string
+	): void {
+		const doc = this.binderItemToDocument(item, parentPath, inheritedSectionType);
+		out.push(doc);
 
 		const children = item.Children?.BinderItem;
 		if (!children) return;
 		const childPath = `${parentPath}${item.Title}/`;
+		const childDefault = this.childDefaultOf(item) ?? doc.sectionTypeId;
 		const items = Array.isArray(children) ? children : [children];
 		for (const child of items) {
-			this.collectDocuments(child, childPath, out);
+			this.collectDocuments(child, childPath, out, childDefault);
 		}
 	}
 
 	private buildDocumentTree(
 		container: BinderContainer,
 		documents: ScrivenerDocument[],
-		parentPath: string
+		parentPath: string,
+		inheritedSectionType?: string
 	): void {
 		if (!container.BinderItem) return;
 
@@ -975,18 +988,37 @@ export class DocumentManager {
 			? container.BinderItem
 			: [container.BinderItem];
 		for (const item of items) {
-			const doc = this.binderItemToDocument(item, parentPath);
+			const doc = this.binderItemToDocument(item, parentPath, inheritedSectionType);
 			documents.push(doc);
 
 			if (item.Children?.BinderItem) {
 				const childPath = `${parentPath}${item.Title}/`;
 				doc.children = [];
-				this.buildDocumentTree(item.Children, doc.children, childPath);
+				this.buildDocumentTree(
+					item.Children,
+					doc.children,
+					childPath,
+					this.childDefaultOf(item) ?? doc.sectionTypeId
+				);
 			}
 		}
 	}
 
-	private binderItemToDocument(item: BinderItem, parentPath: string): ScrivenerDocument {
+	/** A folder's own ChildDefault, if it sets one for its descendants. */
+	private childDefaultOf(item: BinderItem): string | undefined {
+		if (!item.MetaData) return undefined;
+		const metadata = Array.isArray(item.MetaData) ? item.MetaData[0] : item.MetaData;
+		const sectionType = (metadata as { SectionType?: unknown }).SectionType;
+		return sectionType && typeof sectionType === 'object'
+			? (sectionType as { ChildDefault?: string }).ChildDefault
+			: undefined;
+	}
+
+	private binderItemToDocument(
+		item: BinderItem,
+		parentPath: string,
+		inheritedSectionType?: string
+	): ScrivenerDocument {
 		const doc: ScrivenerDocument = {
 			id: item.UUID || '',
 			title: item.Title || 'Untitled',
@@ -1001,6 +1033,16 @@ export class DocumentManager {
 			const metadata = Array.isArray(item.MetaData)
 				? item.MetaData[0]
 				: (item.MetaData as MetaDataItem);
+
+			// A plain string is the item's own override; an object means only
+			// ChildDefault was set (a folder's default for its children, not for
+			// itself), so this item still falls back to the inherited value.
+			const ownSectionType =
+				typeof metadata.SectionType === 'string' ? metadata.SectionType : undefined;
+			const resolvedSectionType = ownSectionType ?? inheritedSectionType;
+			if (resolvedSectionType) {
+				doc.sectionTypeId = resolvedSectionType;
+			}
 
 			if (metadata.Synopsis) {
 				doc.synopsis = metadata.Synopsis;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,8 @@ export interface ScrivenerDocument {
 	customMetadata?: Record<string, string>;
 	keywords?: string[];
 	metadata?: Record<string, string>;
+	/** Resolved Section Type ID: this item's own override, or the nearest ancestor's ChildDefault. */
+	sectionTypeId?: string;
 }
 
 export interface ScrivenerMetadata {

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -53,6 +53,14 @@ export interface BinderMetaData {
 	Keywords?: string;
 	Created?: string;
 	Modified?: string;
+	/**
+	 * A document's own section-type override is plain text (xml2js collapses
+	 * `<SectionType>ID</SectionType>` to a string). A folder's default for its
+	 * children carries the `ChildDefault` attribute instead, which xml2js
+	 * merges onto an object (`<SectionType ChildDefault="ID"></SectionType>`).
+	 * Both can be present on the same folder at once.
+	 */
+	SectionType?: string | { ChildDefault?: string; _?: string };
 	CustomMetaData?: {
 		MetaDataItem?: MetaDataItem | MetaDataItem[];
 	};

--- a/tests/unit/services/compilation-service.test.ts
+++ b/tests/unit/services/compilation-service.test.ts
@@ -504,4 +504,43 @@ describe('CompilationService', () => {
 			});
 		});
 	});
+
+	describe('compileStructured with sectionLayouts', () => {
+		const entries = [
+			{ title: 'Chapter One', content: 'First chapter body.', depth: 1, isFolder: false, sectionTypeId: 'chapter-type' },
+			{ title: 'Chapter Two', content: 'Second chapter body.', depth: 1, isFolder: false, sectionTypeId: 'chapter-type' },
+		];
+
+		it('renders auto-numbered titles and a page break for a recognized CHAPTER-NUMBER layout', () => {
+			const result = compilationService.compileStructured(entries, {
+				sectionLayouts: { 'chapter-type': 'CHAPTER-NUMBER' },
+			});
+
+			expect(result).toContain('Chapter 1');
+			expect(result).toContain('Chapter 2');
+			expect(result).not.toContain('Chapter One');
+			expect(result).toContain('\f');
+		});
+
+		it('falls back to generic includeTitles/sceneSeparator behavior for an unrecognized layout', () => {
+			const result = compilationService.compileStructured(entries, {
+				sectionLayouts: { 'chapter-type': 'CUSTOM-GUID-LAYOUT-1234' },
+				sceneSeparator: '* * *',
+			});
+
+			expect(result).toContain('Chapter One');
+			expect(result).toContain('Chapter Two');
+			expect(result).not.toContain('\f');
+		});
+
+		it('ignores sectionLayouts for an entry with no matching sectionTypeId', () => {
+			const result = compilationService.compileStructured(
+				[{ title: 'Untyped', content: 'body', depth: 1, isFolder: false }],
+				{ sectionLayouts: { 'chapter-type': 'CHAPTER-NUMBER' } }
+			);
+
+			expect(result).toContain('Untyped');
+			expect(result).not.toContain('Chapter 1');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- resolve each document's effective Section Type while building the project structure (its own override, or the nearest ancestor folder's `ChildDefault`)
- add an opt-in `compileFormatId` option to `compile_documents` (mode `structured`): when given, sections whose Section Type maps to a recognized standard layout in that compile format get real title-visibility, chapter auto-numbering, and page-break behavior instead of the generic `includeTitles`/`sceneSeparator` handling
- omitting `compileFormatId` leaves `compile_documents` completely unchanged

## Why / scope

Settings/compile.xml only ever stores a layout *ID* per section type - the layout's actual rendering rules (title format, separators, page breaks) live in Scrivener's own format-preset files, outside the `.scriv` package entirely, and can't be read from project data. This recognizes the handful of standard layout IDs every built-in format preset uses (`TEXT-SECTION`, `TEXT-WITH-HEADER`, `CHAPTER-NUMBER`, `NEW-PAGE-HEADER`, `AS-IS`) and applies their well-established behavior. Custom/unrecognized layout IDs (opaque GUIDs) fall back to today's generic behavior unchanged - this is best-effort standard-layout support, not full Scrivener compile fidelity, and is documented as such in the tool description.

Fixes #14.

## Validation

- `npx tsc --noEmit` clean
- `npx eslint .` clean
- full suite: 54/54 suites, 616 passed, 10 skipped (pre-existing quarantined files, unrelated), exit 0
- new tests cover: recognized numbered/page-break layout, unrecognized-layout fallback, and no-sectionTypeId fallback