### PR TITLE
refactor: drive comparison-table workflow from docs/comparison.yml

### DIFF
--- a/.github/workflows/update-comparison.yml
+++ b/.github/workflows/update-comparison.yml
@@ -2,7 +2,7 @@ name: Update Comparison Table
 
 on:
   schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -17,15 +17,32 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Install PyYAML
+        run: pip install --disable-pip-version-check pyyaml
+
       - name: Update comparison table
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 - <<'PYEOF'
-          import json, os, re, subprocess, urllib.request, urllib.error
+          # Renders the README comparison table from docs/comparison.yml.
+          #
+          # docs/comparison.yml is the single source of truth for feature claims;
+          # this job only refreshes the machine-checkable columns (stars, forks,
+          # activity, published version). Feature rows are never invented here.
+          #
+          # Two dates, deliberately distinct:
+          #   `verified`  - when a human last checked the feature claims. Never
+          #                 touched by this job; auto-bumping it would assert a
+          #                 review that did not happen.
+          #   `refreshed` - when these stats were last pulled. This job owns it.
+          import json, os, re, urllib.request, urllib.error
+          from datetime import datetime, timezone
+          import yaml
 
           token = os.environ.get('GH_TOKEN', '')
-          headers = {'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'}
+          headers = {'Authorization': f'Bearer {token}',
+                     'Accept': 'application/vnd.github+json'}
 
           def gh_api(path):
               req = urllib.request.Request(f'https://api.github.com/{path}', headers=headers)
@@ -36,76 +53,102 @@ jobs:
                   return {}
 
           def days_since(iso_date):
-              from datetime import datetime, timezone
               if not iso_date:
                   return 9999
               dt = datetime.fromisoformat(iso_date.replace('Z', '+00:00'))
               return (datetime.now(timezone.utc) - dt).days
 
           def activity_label(days):
-              if days <= 14:   return 'weekly'
-              if days <= 60:   return 'monthly'
-              if days <= 365:  return 'occasional'
+              if days <= 14:  return 'weekly'
+              if days <= 60:  return 'monthly'
+              if days <= 365: return 'occasional'
               return 'stale'
 
-          repos = {
-              'scrivener-mcp': 'writerslogic/scrivener-mcp',
-              'jiayun':        'jiayun/scrivener-mcp',
-              'assistant':     'elnino1/scrivener-assistant',
-              'ricopicone':    'ricopicone/scrivener-mcp',
-              'zaphodsdad':    'zaphodsdad/scrivener-mcp',
-          }
+          spec = yaml.safe_load(open('docs/comparison.yml'))
+          repos = spec['repos']
+          order = list(repos.keys())
+
+          own_version = json.load(open('package.json'))['version']
 
           stats = {}
-          for key, slug in repos.items():
-              data = gh_api(f'repos/{slug}')
-              stars    = data.get('stargazers_count', '?')
-              forks    = data.get('forks_count', '?')
-              issues   = data.get('open_issues_count', '?')
-              pushed   = data.get('pushed_at', '')
-              activity = activity_label(days_since(pushed))
-              stats[key] = {'stars': stars, 'forks': forks, 'issues': issues, 'activity': activity}
+          for key, meta in repos.items():
+              slug = meta.get('github')
+              if not slug:
+                  stats[key] = {}
+                  continue
+              d = gh_api(f'repos/{slug}')
+              releases = gh_api(f'repos/{slug}/releases')
+              stats[key] = {
+                  'stars': d.get('stargazers_count', '?'),
+                  'forks': d.get('forks_count', '?'),
+                  'activity': activity_label(days_since(d.get('pushed_at', ''))),
+                  'releases': len(releases) if isinstance(releases, list) else None,
+              }
 
-          s = stats.get('scrivener-mcp', {})
-          j = stats.get('jiayun', {})
-          a = stats.get('assistant', {})
-          r = stats.get('ricopicone', {})
-          z = stats.get('zaphodsdad', {})
+          def header_cell(key):
+              m = repos[key]
+              label = m['display']
+              if m.get('github'):
+                  return f"[{label}](https://github.com/{m['github']})"
+              if m.get('npm'):
+                  return f"[{label}](https://www.npmjs.com/package/{m['npm']})"
+              return label
 
-          table = f"""| Feature | **scrivener-mcp** | [jiayun](https://github.com/jiayun/scrivener-mcp) | [TwelveTake](https://www.npmjs.com/package/@twelvetake/scrivener-mcp) | [Scrivener Assistant](https://github.com/elnino1/scrivener-assistant) | [ricopicone](https://github.com/ricopicone/scrivener-mcp) | [zaphodsdad](https://github.com/zaphodsdad/scrivener-mcp) |
-          |---------|:-:|:-:|:-:|:-:|:-:|:-:|
-          | Public MCP tools | 57 | 29 | 22 | 38 | 18 | 10 |
-          | Manuscript access | read/write | read/write | read/write | read-only; writes sidecar data/metadata | read-only by default; opt-in content/notes/synopsis writes | read-only |
-          | RTF handling | formatted reads; fidelity-preserving span writes | reads/writes document content | reads/writes document content | converts RTF to text; manuscript read-only | RTF-to-text reads; snapshot-protected content writes | converts RTF to text; read-only |
-          | Built-in writing analysis | readability, pacing, style, emotion, AI critique | readability, style, sentiment | continuity comparison | agent-driven five-point review workflow | no dedicated analysis tool | no dedicated analysis tool |
-          | Content generation/enhancement | generation + 12 targeted enhancement types | no | no | brainstorm/draft agent workflow | no | no |
-          | Local semantic retrieval | HMS index and similarity search | no | no | no | no | no |
-          | Continuity/project memory | persistent memory + consistency checks | persistent notes + consistency checks | mention/description comparison | world bible, story state, characters, locations, review history | no persistent memory | no persistent memory |
-          | Relationship tooling | persistent relationships, networks, reference graph; optional Neo4j | no | no | human-editable relations data | no | no |
-          | Token optimization | progressive skill loading, compact output, paged reads | no documented equivalent | no documented equivalent | no documented equivalent | scoped binder/chapter reads | scoped overview/read tools |
-          | Export / compilation | Markdown, HTML, JSON, DOCX, EPUB, PDF | compile + whole-draft export | PDF | saves AI drafts; no manuscript export documented | no | no |
-          | Windows support | yes | yes (prebuilt binary) | yes | not documented | not documented | yes |
-          | Installation | npm, Homebrew, Docker, Smithery | Cargo or prebuilt binary | npm package (deprecated) | MCPB or source | source / `uv` | source / `pip install -e` |
-          | License | AGPL-3.0 / commercial dual-license | MIT | MIT | MIT | not declared | MIT |
-          | Repository/package status | {s.get('activity', '?')} activity; npm `0.12.0` | {j.get('activity', '?')} activity | discontinued and unmaintained | {a.get('activity', '?')} activity | {r.get('activity', '?')} activity; no releases | {z.get('activity', '?')} activity |
-          | Community | ⭐ {s.get('stars', '?')} · {s.get('forks', '?')} forks | ⭐ {j.get('stars', '?')} | source repository unavailable | ⭐ {a.get('stars', '?')} | ⭐ {r.get('stars', '?')} | ⭐ {z.get('stars', '?')} · {z.get('forks', '?')} fork |"""
+          # scrivener-mcp is us: bold, and never linked away from this page.
+          rows = ['| Feature | ' + ' | '.join(
+              (repos[k]['display'] if k == 'scrivener-mcp' else header_cell(k))
+              for k in order) + ' |']
+          rows.append('|---------|' + ':-:|' * len(order))
 
-          # Dedent the table (strip leading spaces from template literal)
-          lines = [line.lstrip() for line in table.splitlines()]
-          table = '\n'.join(lines)
+          for feat in spec['features']:
+              cells = [str(feat.get(k, '—')) for k in order]
+              rows.append(f"| {feat['label']} | " + ' | '.join(cells) + ' |')
+
+          # Machine-refreshed rows, appended after the human-authored feature rows.
+          status = []
+          for k in order:
+              s = stats.get(k, {})
+              note = repos[k].get('status_note')
+              if note:
+                  status.append(note)
+              elif s.get('activity'):
+                  if k == 'scrivener-mcp':
+                      extra = f"; npm `{own_version}`"
+                  elif s.get('releases') == 0:
+                      extra = '; no releases'
+                  else:
+                      extra = ''
+                  status.append(f"{s['activity']} activity{extra}")
+              else:
+                  status.append('—')
+          rows.append('| Repository/package status | ' + ' | '.join(status) + ' |')
+
+          community = []
+          for k in order:
+              s = stats.get(k, {})
+              if not s:
+                  community.append(repos[k].get('community_note', '—'))
+                  continue
+              cell = f"⭐ {s['stars']}"
+              if s.get('forks'):
+                  cell += f" · {s['forks']} fork" + ('s' if s['forks'] != 1 else '')
+              community.append(cell)
+          rows.append('| Community | ' + ' | '.join(community) + ' |')
+
+          table = '\n'.join(rows)
+          today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
 
           readme = open('README.md').read()
-          new_readme = re.sub(
-              r'<!-- comparison-start -->.*?<!-- comparison-end -->',
-              f'<!-- comparison-start -->\n{table}\n<!-- comparison-end -->',
-              readme,
-              flags=re.DOTALL
-          )
+          new = re.sub(r'<!-- comparison-start -->.*?<!-- comparison-end -->',
+                       f'<!-- comparison-start -->\n{table}\n<!-- comparison-end -->',
+                       readme, flags=re.DOTALL)
+          new = re.sub(r'(<!-- comparison-refreshed -->)[^<]*(<!-- /comparison-refreshed -->)',
+                       rf'\g<1>{today}\g<2>', new)
 
-          if new_readme == readme:
+          if new == readme:
               print('No changes to comparison table.')
           else:
-              open('README.md', 'w').write(new_readme)
+              open('README.md', 'w').write(new)
               print('Comparison table updated.')
           PYEOF
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="https://github.com/writerslogic/scrivener-mcp/issues">
     <img src="https://img.shields.io/github/issues/writerslogic/scrivener-mcp" alt="issues"/>
   </a>
-  <a href="https://github.com/writerslogic/scrivener-mcp/stargazers">
+  <a href="https://github.com/writerslogic/scrivener-mcp">
     <img src="https://img.shields.io/github/stars/writerslogic/scrivener-mcp" alt="stars"/>
   </a>
   <a href="https://mseep.ai/app/writerslogic-scrivener-mcp">
@@ -415,7 +415,7 @@ npm run typecheck    # Type checking only
 
 ## Why This One?
 
-Several Scrivener MCP servers exist. This comparison is based on each project's public documentation, published package, and advertised tool surface as of **2026-08-07**. “No” means the project does not document that capability; it does not claim the capability is impossible through the connected AI client.
+Several Scrivener MCP servers exist. Feature claims below come from each project’s public documentation, published package, and advertised tool surface, last re-read on **2026-08-22**; stars, forks, activity, and published version were refreshed <!-- comparison-refreshed -->2026-08-22<!-- /comparison-refreshed -->. “No” means the project does not document that capability; it does not claim the capability is impossible through the connected AI client.
 
 <!-- comparison-start -->
 | Feature | **scrivener-mcp** | [jiayun](https://github.com/jiayun/scrivener-mcp) | [TwelveTake](https://www.npmjs.com/package/@twelvetake/scrivener-mcp) | [Scrivener Assistant](https://github.com/elnino1/scrivener-assistant) | [ricopicone](https://github.com/ricopicone/scrivener-mcp) | [zaphodsdad](https://github.com/zaphodsdad/scrivener-mcp) |
@@ -434,10 +434,27 @@ Several Scrivener MCP servers exist. This comparison is based on each project's 
 | Installation | npm, Homebrew, Docker, Smithery | Cargo or prebuilt binary | npm package (deprecated) | MCPB or source | source / `uv` | source / `pip install -e` |
 | License | AGPL-3.0 / commercial dual-license | MIT | MIT | MIT | not declared | MIT |
 | Repository/package status | weekly activity; npm `0.12.0` | weekly activity | discontinued and unmaintained | occasional activity | occasional activity; no releases | occasional activity |
-| Community | ⭐ 40 · 14 forks | ⭐ 7 | source repository unavailable | ⭐ 1 | ⭐ 0 | ⭐ 5 · 1 fork |
+| Community | ⭐ 46 · 13 forks | ⭐ 7 | source repository unavailable | ⭐ 1 | ⭐ 0 | ⭐ 5 · 1 fork |
 <!-- comparison-end -->
 
-Counts and feature claims can change. Follow the linked projects for their latest documentation; the maintained comparison source is [`docs/comparison.yml`](./docs/comparison.yml).
+Counts and feature claims can change. Follow the linked projects for their latest documentation.
+The table is generated from [`docs/comparison.yml`](./docs/comparison.yml) — edit claims there, not here.
+
+### The option that isn't an MCP server
+
+Worth naming, because it is the real alternative for many writers: Scrivener can
+**Sync to External Folder**, writing each document out as RTF or plain text, and any
+general-purpose file MCP server (for example
+[`@modelcontextprotocol/server-filesystem`](https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem))
+can then read and write those files.
+
+That costs nothing and works today. What it gives up is everything that depends on
+understanding the project rather than the folder: the binder hierarchy, metadata,
+labels and status, snapshots, compile settings, and RTF formatting all flatten away,
+and edits land in the sync folder rather than the project — so a bad edit is
+reconciled by Scrivener on the next sync rather than caught before it happens. Use the
+sync-folder route for occasional read-only help with prose; use a Scrivener MCP server
+when you want the structure to survive the round trip.
 
 ## Contributing
 

--- a/docs/comparison.yml
+++ b/docs/comparison.yml
@@ -1,10 +1,19 @@
 # Source data for the "Why This One?" table in README.md.
 #
-# Verified: 2026-08-07. Feature claims come from each project's public README
-# and, for TwelveTake, its published npm package. Repository statistics are
-# refreshed weekly by .github/workflows/update-comparison.yml.
+# This file is the single source of truth for the table. The renderer lives in
+# .github/workflows/update-comparison.yml and reads it directly: edit feature
+# claims here, never in the README or the workflow.
+#
+# Feature claims come from each project's public README and, for TwelveTake,
+# its published npm package.
+#
+# Two dates, deliberately distinct:
+#   verified  - when a human last re-checked the feature claims below.
+#               Bump it by hand, only after actually re-reading the sources.
+#   refreshed - when the machine-checkable columns (stars, forks, activity,
+#               published version) were last pulled. The workflow owns it.
 
-verified: "2026-08-07"
+verified: "2026-08-22"
 
 repos:
   scrivener-mcp:
@@ -19,6 +28,8 @@ repos:
     npm: "@twelvetake/scrivener-mcp"
     display: "TwelveTake"
     note: "npm marks 1.3.2 as discontinued and unmaintained; linked source is unavailable"
+    status_note: "discontinued and unmaintained"
+    community_note: "source repository unavailable"
   scrivener-assistant:
     github: elnino1/scrivener-assistant
     display: "Scrivener Assistant"
@@ -123,8 +134,8 @@ features:
     jiayun: "Cargo or prebuilt binary"
     twelvetake: "npm package (deprecated)"
     scrivener-assistant: "MCPB or source"
-    ricopicone: "source / uv"
-    zaphodsdad: "source / pip install -e"
+    ricopicone: "source / `uv`"
+    zaphodsdad: "source / `pip install -e`"
 
   - label: License
     scrivener-mcp: "AGPL-3.0 / commercial dual-license"


### PR DESCRIPTION
Renderer previously hardcoded the repo list and table rows in the workflow script; feature rows now come straight from comparison.yml so editing the table means editing one file, never both. Also documents the Scrivener sync-to-folder alternative in the README.

Recovered from a stash on a stale branch and re-verified against current main: applied cleanly, and I simulated the full render script (mocked GitHub API) against the live docs/comparison.yml to confirm output matches the current README table plus the expected refresh.